### PR TITLE
Add subscription type

### DIFF
--- a/lib/ews/types/generic_folder.rb
+++ b/lib/ews/types/generic_folder.rb
@@ -253,7 +253,7 @@ module Viewpoint::EWS::Types
       if rmsg.success?
         @subscription_id = rmsg.subscription_id
         @watermark = rmsg.watermark
-        true
+        class_by_name(rmsg.type).new(ews, rmsg.message)
       else
         raise EwsSubscriptionError, "Could not subscribe: #{rmsg.code}: #{rmsg.message_text}"
       end

--- a/lib/ews/types/subscribe_response_message.rb
+++ b/lib/ews/types/subscribe_response_message.rb
@@ -1,0 +1,7 @@
+module Viewpoint::EWS::Types
+  class SubscribeResponseMessage
+    include Viewpoint::EWS
+    include Viewpoint::EWS::Types
+    include Viewpoint::EWS::Types::Subscription
+  end
+end

--- a/lib/ews/types/subscription.rb
+++ b/lib/ews/types/subscription.rb
@@ -1,0 +1,58 @@
+module Viewpoint::EWS::Types
+  module Subscription
+    include Viewpoint::EWS
+    include Viewpoint::EWS::Types
+
+    def self.included(klass)
+      klass.extend ClassMethods
+    end
+
+    module ClassMethods
+      def init_simple_item(ews, id, watermark = nil, parent = nil)
+        ews_item = {subscription_id: {attribs: {id: id, watermark: watermark}}}
+        self.new ews, ews_item, parent
+      end
+    end
+
+    SUBSCRIPTION_KEY_PATHS = {
+      subscription_id: [:elems, :subscription_id, :text],
+      watermark:       [:elems, :watermark, :text]
+    }
+
+    SUBSCRIPTION_KEY_TYPES = {
+      subscription_id:    ->(str){str.to_s},
+      watermark:          ->(str){str.to_s}
+    }
+
+    SUBSCRIPTION_KEY_ALIAS = {
+    }
+
+    attr_reader :ews_item, :parent
+
+    # @param ews [SOAP::ExchangeWebService] the EWS reference
+    # @param ews_item [Hash] the EWS parsed response document
+    # @param parent [GenericFolder] an optional parent object
+    def initialize(ews, ews_item, parent = nil)
+      super(ews, ews_item)
+      @parent = parent
+    end
+
+    def get_all_properties!
+      @ews_item
+    end
+
+    private
+
+    def key_paths
+      super.merge(SUBSCRIPTION_KEY_PATHS)
+    end
+
+    def key_types
+      super.merge(SUBSCRIPTION_KEY_TYPES)
+    end
+
+    def key_alias
+      super.merge(SUBSCRIPTION_KEY_ALIAS)
+    end
+  end
+end

--- a/lib/viewpoint.rb
+++ b/lib/viewpoint.rb
@@ -87,6 +87,8 @@ require 'ews/types/mailbox_user'
 require 'ews/types/out_of_office'
 require 'ews/types/export_items_response_message'
 require 'ews/types/post_item'
+require 'ews/types/subscription'
+require 'ews/types/subscribe_response_message'
 
 # Events
 require 'ews/types/event'


### PR DESCRIPTION
This PR adds a `Viewpoint::EWS::Types::SubscribeResponseMessage` and `Viewpoint::EWS::Types::Subscription` types that we return when creating a push subscription.