### PR TITLE
Make use of system certs to ensure all SSL encryption can work

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -47,6 +47,9 @@ class Viewpoint::EWS::Connection
       opts[:trust_ca].each do |ca|
         @httpcli.ssl_config.add_trust_ca ca
       end
+    else
+      @httpcli.ssl_config.clear_cert_store
+      @httpcli.ssl_config.cert_store.set_default_paths
     end
 
     @httpcli.ssl_config.verify_mode = opts[:ssl_verify_mode] if opts[:ssl_verify_mode]


### PR DESCRIPTION
The certificates included in HTTPClient are from circa 2015ish, meaning nothing from Letsencrypt work with it. By clearing the cert store and then setting the default path we make use of the latest certs from the installed OS.