### PR TITLE
Add item_class to the returned object

### DIFF
--- a/lib/ews/types/item.rb
+++ b/lib/ews/types/item.rb
@@ -17,6 +17,7 @@ module Viewpoint::EWS::Types
 
     ITEM_KEY_PATHS = {
       item_id:        [:item_id, :attribs],
+      item_class:     [:item_class, :text],
       id:             [:item_id, :attribs, :id],
       change_key:     [:item_id, :attribs, :change_key],
       subject:        [:subject, :text],


### PR DESCRIPTION
This PR adds the item_class property to the email item, which allows us to make use of the classes listed [here](https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-asemail/51d84da6-a2da-41e9-8ca7-eb6c4e72c28d?redirectedfrom=MSDN) to determine auto replies, bounces, etc