### PR TITLE
Add the item id of the modified occurence to the hash

### DIFF
--- a/lib/ews/types/item.rb
+++ b/lib/ews/types/item.rb
@@ -363,6 +363,7 @@ module Viewpoint::EWS::Types
           elems = a[:occurrence][:elems]
 
           h[DateTime.parse(elems.find{|e| e[:original_start]}[:original_start][:text])] = {
+            item_id: elems.find{|e| e[:item_id]}[:item_id][:attribs][:id],
             start: elems.find{|e| e[:start]}[:start][:text],
             end: elems.find{|e| e[:end]}[:end][:text]
           }


### PR DESCRIPTION
This is needed to solve the issue of the main app not being able to find the relevant meeting occurrence due to the id not being part of the hash.