### PR TITLE
Add calendar_item_type to the calendar items

### DIFF
--- a/lib/ews/types/calendar_item.rb
+++ b/lib/ews/types/calendar_item.rb
@@ -14,6 +14,7 @@ module Viewpoint::EWS::Types
       start:        [:start, :text],
       end:          [:end, :text],
       location:     [:location, :text],
+      calendar_item_type: [:calendar_item_type, :text],
       all_day?:     [:is_all_day_event, :text],
       legacy_free_busy_status: [:legacy_free_busy_status, :text],
       my_response_type:   [:my_response_type, :text],


### PR DESCRIPTION
This allows us to easily differentiate between RecurringMaster, Occurence & Single